### PR TITLE
Better support for Metal GPUs

### DIFF
--- a/cellstream/cwt/utils.py
+++ b/cellstream/cwt/utils.py
@@ -41,7 +41,7 @@ def query_cwt_block(
     normalize_amplitudes=False,
     carrier_channel=0,
     channel_outputs={0: ["amp", "freq", "phase"]},
-    use_gpu=False,
+    device="cpu",
     bank_method="max_pool",
     sampling=None,
     **ssqueezepy_cwt_kwargs,
@@ -60,7 +60,7 @@ def query_cwt_block(
     """
 
     # Force environment variable BEFORE import
-    os.environ["SSQ_GPU"] = "1" if use_gpu else "0"
+    os.environ["SSQ_GPU"] = "1" if "cuda" in device else "0"
     from ssqueezepy import cwt
 
     # Prepare shapes
@@ -90,7 +90,10 @@ def query_cwt_block(
     # Find max_scale channels along scale dimension
 
     carrier_amp = split_channels[carrier_channel].abs()
-    carrier_phase = split_channels[carrier_channel].angle()
+    try:
+        carrier_phase = split_channels[carrier_channel].angle()
+    except NotImplemented:
+        carrier_phase = split_channels[carrier_channel].cpu().angle().to_device(device)
 
     # manage filter-banking methods:
 
@@ -114,7 +117,12 @@ def query_cwt_block(
         carrier_amp, carrier_freq = torch.sort(
             split_channels[carrier_channel].abs(), axis=1, descending=True
         )
-        carrier_phase = split_channels[carrier_channel].angle()
+        try:
+            carrier_phase = split_channels[carrier_channel].angle()
+        except NotImplemented:
+            carrier_phase = (
+                split_channels[carrier_channel].cpu().angle().to_device(device)
+            )
         carrier_phase = torch.gather(carrier_phase, 1, carrier_freq)
 
     # Prepare outputs dictionary
@@ -143,7 +151,7 @@ def query_cwt_block(
             BATCH_SIZE, T, -1
         )
         freqs_lookup = freqs_lookup.permute(0, 2, 1)  # (batch, scales, time)
-        if use_gpu:
+        if "cuda" in device:
             freqs_lookup = freqs_lookup.to("cuda")
         carrier_freq_converted = torch.gather(freqs_lookup, 1, carrier_freq + min_scale)
 
@@ -153,7 +161,10 @@ def query_cwt_block(
             P = P / split_channels_full_power_sums[channel]
         if ("phase" in returns) or ("phase_difference" in returns):
             # only compute phase if needed
-            PH = split_channels[channel].angle()
+            try:
+                PH = split_channels[channel].angle()
+            except NotImplemented:
+                PH = split_channels[channel].cpu().angle().to_device(device)
             ch_ph = torch.gather(PH, 1, carrier_freq)
         if "phase" in returns:
             results[channel]["phase"] = ch_ph[:, :num_filter_banks, :].cpu()
@@ -195,7 +206,7 @@ def generate_cwt_image_cellstreams(
     num_filter_banks=1,
     normalize_amplitudes=False,
     blocks=10,
-    use_gpu=False,
+    device="cpu",
     bank_method="max_pool",
     downsample_by=None,
     normalize_histogram=True,
@@ -216,7 +227,7 @@ def generate_cwt_image_cellstreams(
         Dictionary of requested outputs as numpy arrays
     """
     # gpu environment setup for squeezepy
-    os.environ["SSQ_GPU"] = "1" if use_gpu else "0"
+    os.environ["SSQ_GPU"] = "1" if "cuda" in device else "0"
 
     img = normalize_dims(img, 1)
 
@@ -267,7 +278,7 @@ def generate_cwt_image_cellstreams(
             normalize_amplitudes=normalize_amplitudes,
             carrier_channel=carrier_channel,
             channel_outputs=channel_outputs,
-            use_gpu=use_gpu,
+            device=device,
             sampling=sampling,
             **ssqueezepy_cwt_kwargs,
         )

--- a/cellstream/fft/utils.py
+++ b/cellstream/fft/utils.py
@@ -122,7 +122,10 @@ def generate_fft_features(
                 buffers["z_score"][:, :, start:end] = z[:max_bin].cpu()
 
             if "phase" in fft_features_to_process:
-                phase = fft_chunk.angle()
+                try:
+                    phase = fft_chunk.angle()
+                except NotImplemented:
+                    phase = fft_chunk.cpu().angle().to_device(device)
                 buffers["phase"][:, :, start:end] = phase[:max_bin].cpu()
 
             bar.update(end)
@@ -146,7 +149,10 @@ def generate_fft_features(
             feature_map["z_score"] = z[:max_bin]
 
         if "phase" in fft_features_to_process:
-            phase = fft.angle()
+            try:
+                phase = fft.angle()
+            except NotImplemented:
+                phase = fft.cpu().angle().to_device(device)
             feature_map["phase"] = phase[:max_bin]
 
     return feature_map

--- a/cellstream/image/utils.py
+++ b/cellstream/image/utils.py
@@ -194,8 +194,6 @@ def color_by_axis(img: torch.Tensor, cmap="turbo", proj="max", minmax_norm=True)
     return out
 
 
-
-
 # patch napari to accept tensors for adding to viewer
 def _to_numpy(x):
     if isinstance(x, torch.Tensor):

--- a/examples/cellstream_cwt_example___extract_streams.py
+++ b/examples/cellstream_cwt_example___extract_streams.py
@@ -19,7 +19,7 @@ cwt_features = cellstream.cwt.generate_cwt_image_cellstreams(
     max_scale=150,
     num_filter_banks=1,
     blocks=50,
-    use_gpu=True,
+    device="cuda:0",
     bank_method="sort",
     normalize_amplitudes=False,
     ###pre-processing

--- a/examples/cellstream_cwt_example___generate_cwts.py
+++ b/examples/cellstream_cwt_example___generate_cwts.py
@@ -19,7 +19,7 @@ results = cellstream.cwt.generate_cwt_image_cellstreams(
     max_scale=180,
     num_filter_banks=20,
     blocks=50,
-    use_gpu=True,
+    device="cuda",
     bank_method="max_pool",
     normalize_amplitudes=False,
     ###pre-processing


### PR DESCRIPTION
# Better Support for Metal GPUs

Cellstream currently faces two issues in support for Metal GPUs:

1. Complex angle calculations are not implemented for pytorch-metal builds.
2. Ssqueezepy does not support Metal GPUs.

This pull request creates a workaround for (1) and rewrites some functions to make (2) clearer.

## 1. Workaround NotImplemented error

Because the complex angle calculation is not implemented, it makes sense to simply perform the calculation on the CPU rather than the GPU.
eweix/cellstream@3209cd22bb02 uses a try/except block to move the angle computation to the CPU if it is unavailable.
The tensor is then moved back to whichever device was specified for the remainder of the calculations.

## 2. Change cwt functions to better support MPS

Fully supporting CWT acceleration on MPS would require a complete rewrite of the ssqueezepy package.
This seems to be outside of the scope of this project.
eweix/cellstream@da74ebb3dbc1 replaces the `use_gpu` argument in `query_cwt_block()` with an argument called `device`.
`device` takes a `torch.device` as input and determines the device that the computation will try to use.
If the device is a cuda device, then ssqueezepy will be told to go right on ahead with the GPU.
Otherwise, ssqueezepy will perform the computation on the CPU.
This also makes the arguments for the CWT functions congruent with the FFT function arguments.

- **fix: handle NotImplemented error in fft angle computation**
- **feat!: BREAKING CHANGE partially support mps cwt acceleration**
- **chore: linting**
